### PR TITLE
52 generate fat jar from the nmf app

### DIFF
--- a/src/saasy-ml-app/pom.xml
+++ b/src/saasy-ml-app/pom.xml
@@ -90,7 +90,7 @@
       <version>3.12.0</version>
     </dependency>
 
-    <!-- Vertx Dependencies -->
+    <!-- API server Dependencies -->
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-config</artifactId>
@@ -150,6 +150,29 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
       </plugin>
+            
+      <plugin>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <configuration>
+              <archive>
+                  <manifest>
+                      <mainClass>${assembly.mainClass}</mainClass>
+                  </manifest>
+              </archive>
+              <descriptorRefs>
+                  <descriptorRef>jar-with-dependencies</descriptorRef>
+              </descriptorRefs>
+          </configuration>
+          <executions>
+              <execution>
+                  <id>make-assembly</id>
+                  <phase>package</phase>
+                  <goals>
+                      <goal>single</goal>
+                  </goals>
+              </execution>
+          </executions>
+      </plugin>
     </plugins>
   </build>
   
@@ -173,6 +196,7 @@
                 </execution>
               </executions>
             </plugin>
+
         </plugins>
       </build>
     </profile>

--- a/src/saasy-ml-app/src/main/java/esa/mo/nmf/apps/AggregationHandler.java
+++ b/src/saasy-ml-app/src/main/java/esa/mo/nmf/apps/AggregationHandler.java
@@ -24,7 +24,7 @@ import org.ccsds.moims.mo.mc.aggregation.structures.AggregationParameterSetList;
 import org.ccsds.moims.mo.mc.parameter.consumer.ParameterStub;
 import org.ccsds.moims.mo.mc.structures.ObjectInstancePairList;
 
-import esa.mo.nmf.apps.exceptions.AddAggregationDidNotReturnAggregationId;
+import esa.mo.nmf.apps.saasyml.api.exceptions.AddAggregationDidNotReturnAggregationId;
 
 
 public class AggregationHandler {

--- a/src/saasy-ml-app/src/main/java/esa/mo/nmf/apps/AggregationWriter.java
+++ b/src/saasy-ml-app/src/main/java/esa/mo/nmf/apps/AggregationWriter.java
@@ -11,6 +11,7 @@ import org.ccsds.moims.mo.mc.parameter.structures.ParameterValue;
 
 import esa.mo.helpertools.helpers.HelperAttributes;
 import esa.mo.mc.impl.provider.AggregationInstance;
+import esa.mo.nmf.apps.saasyml.api.Constants;
 import esa.mo.nmf.commonmoadapter.CompleteAggregationReceivedListener;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;

--- a/src/saasy-ml-app/src/main/java/esa/mo/nmf/apps/SaaSyMLApp.java
+++ b/src/saasy-ml-app/src/main/java/esa/mo/nmf/apps/SaaSyMLApp.java
@@ -5,7 +5,7 @@ import java.util.logging.Logger;
 import esa.mo.nmf.nanosatmoconnector.NanoSatMOConnectorImpl;
 import esa.mo.nmf.spacemoadapter.SpaceMOApdapterImpl;
 
-import esa.mo.nmf.apps.verticles.MainVerticle;
+import esa.mo.nmf.apps.saasyml.api.verticles.MainVerticle;
 
 
 /**

--- a/src/saasy-ml-app/src/main/java/esa/mo/nmf/apps/saasyml/api/Constants.java
+++ b/src/saasy-ml-app/src/main/java/esa/mo/nmf/apps/saasyml/api/Constants.java
@@ -1,4 +1,4 @@
-package esa.mo.nmf.apps;
+package esa.mo.nmf.apps.saasyml.api;
 
 public final class Constants {
 

--- a/src/saasy-ml-app/src/main/java/esa/mo/nmf/apps/saasyml/api/exceptions/AddAggregationDidNotReturnAggregationId.java
+++ b/src/saasy-ml-app/src/main/java/esa/mo/nmf/apps/saasyml/api/exceptions/AddAggregationDidNotReturnAggregationId.java
@@ -1,4 +1,4 @@
-package esa.mo.nmf.apps.exceptions;
+package esa.mo.nmf.apps.saasyml.api.exceptions;
 
 public class AddAggregationDidNotReturnAggregationId extends Exception {
     private static final long serialVersionUID = 1L;

--- a/src/saasy-ml-app/src/main/java/esa/mo/nmf/apps/saasyml/api/exceptions/NotEnoughParamsForRequestedType.java
+++ b/src/saasy-ml-app/src/main/java/esa/mo/nmf/apps/saasyml/api/exceptions/NotEnoughParamsForRequestedType.java
@@ -1,4 +1,4 @@
-package esa.mo.nmf.apps.exceptions;
+package esa.mo.nmf.apps.saasyml.api.exceptions;
 
 public class NotEnoughParamsForRequestedType extends Exception {
     private static final long serialVersionUID = 1L;

--- a/src/saasy-ml-app/src/main/java/esa/mo/nmf/apps/saasyml/api/verticles/DatabaseVerticle.java
+++ b/src/saasy-ml-app/src/main/java/esa/mo/nmf/apps/saasyml/api/verticles/DatabaseVerticle.java
@@ -1,4 +1,4 @@
-package esa.mo.nmf.apps.verticles;
+package esa.mo.nmf.apps.saasyml.api.verticles;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -30,7 +30,7 @@ import java.sql.Timestamp;
 import org.sqlite.SQLiteConfig;
 
 import esa.mo.nmf.apps.ApplicationManager;
-import esa.mo.nmf.apps.Constants;
+import esa.mo.nmf.apps.saasyml.api.Constants;
 import esa.mo.nmf.apps.PropertiesManager;
 
 public class DatabaseVerticle extends AbstractVerticle {

--- a/src/saasy-ml-app/src/main/java/esa/mo/nmf/apps/saasyml/api/verticles/FetchTrainingDataVerticle.java
+++ b/src/saasy-ml-app/src/main/java/esa/mo/nmf/apps/saasyml/api/verticles/FetchTrainingDataVerticle.java
@@ -1,4 +1,4 @@
-package esa.mo.nmf.apps.verticles;
+package esa.mo.nmf.apps.saasyml.api.verticles;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -13,7 +13,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 
 import esa.mo.nmf.apps.ApplicationManager;
-import esa.mo.nmf.apps.Constants;
+import esa.mo.nmf.apps.saasyml.api.Constants;
 
 public class FetchTrainingDataVerticle extends AbstractVerticle {
   

--- a/src/saasy-ml-app/src/main/java/esa/mo/nmf/apps/saasyml/api/verticles/InferenceVerticle.java
+++ b/src/saasy-ml-app/src/main/java/esa/mo/nmf/apps/saasyml/api/verticles/InferenceVerticle.java
@@ -1,4 +1,4 @@
-package esa.mo.nmf.apps.verticles;
+package esa.mo.nmf.apps.saasyml.api.verticles;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -8,7 +8,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-import esa.mo.nmf.apps.Constants;
+import esa.mo.nmf.apps.saasyml.api.Constants;
 import esa.mo.nmf.apps.PropertiesManager;
 import esa.mo.nmf.apps.saasyml.common.IPipeLineLayer;
 import esa.mo.nmf.apps.saasyml.factories.MLPipeLineFactory;

--- a/src/saasy-ml-app/src/main/java/esa/mo/nmf/apps/saasyml/api/verticles/MainVerticle.java
+++ b/src/saasy-ml-app/src/main/java/esa/mo/nmf/apps/saasyml/api/verticles/MainVerticle.java
@@ -1,4 +1,4 @@
-package esa.mo.nmf.apps.verticles;
+package esa.mo.nmf.apps.saasyml.api.verticles;
 
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Vertx;
@@ -12,12 +12,11 @@ import io.vertx.core.json.JsonObject;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import esa.mo.nmf.apps.AppMCAdapter;
-import esa.mo.nmf.apps.Constants;
+import esa.mo.nmf.apps.saasyml.api.Constants;
 import esa.mo.nmf.apps.PropertiesManager;
 
 

--- a/src/saasy-ml-app/src/main/java/esa/mo/nmf/apps/saasyml/api/verticles/TrainModelVerticle.java
+++ b/src/saasy-ml-app/src/main/java/esa/mo/nmf/apps/saasyml/api/verticles/TrainModelVerticle.java
@@ -1,4 +1,4 @@
-package esa.mo.nmf.apps.verticles;
+package esa.mo.nmf.apps.saasyml.api.verticles;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -9,7 +9,7 @@ import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import esa.mo.nmf.apps.Constants;
+import esa.mo.nmf.apps.saasyml.api.Constants;
 import esa.mo.nmf.apps.PropertiesManager;
 import esa.mo.nmf.apps.saasyml.common.IPipeLineLayer;
 import esa.mo.nmf.apps.saasyml.factories.MLPipeLineFactory;


### PR DESCRIPTION
- [X] Refactor the packages to make visibile the API functionality (packages saasyml.api).
- [X] Change the pom.xml to add the fat generation
          - It will be great if we can generate a fat jar only with the specific libraries. I do not know how to do it. @georgeslabreche 
          any idea?

Once the fat jar is generated, we need to remove the unneeded libraries 👎 . For example, all NMF libraries. Just to avoid conflict.